### PR TITLE
look up package.json at call-time, not require-time

### DIFF
--- a/lib/getComponentPath/index.js
+++ b/lib/getComponentPath/index.js
@@ -3,17 +3,17 @@
 const _ = require('lodash'),
   fs = require('fs'),
   path = require('path');
-var getComponentName = require('../getComponentName'),
-  pkg = require(path.resolve(process.cwd(), 'package.json'));
+var getComponentName = require('../getComponentName');
 
 
 /**
  * Get the full name of a possibly-scoped npm component
  *
  * @param {string} name, e.g. 'clay-header'
+ * @param {object} pkg for testing
  * @returns {string|undefined} e.g. '@nymdev/clay-header'
  */
-function getScopedModuleName(name) {
+function getScopedModuleName(name, pkg) {
   return _.findKey(pkg.dependencies, function (version, dep) {
     return _.includes(dep, name);
   });
@@ -23,9 +23,10 @@ function getScopedModuleName(name) {
  * Get path to component folder.
  *
  * @param  {string} name
+ * @param  {object} pkg for testing
  * @return {string}
  */
-function getComponentPath(name) {
+function getComponentPath(name, pkg = require(path.resolve(process.cwd(), 'package.json'))) {
   let result = null,
     modulePath, npmName;
 
@@ -36,7 +37,7 @@ function getComponentPath(name) {
     if (fs.existsSync(modulePath)) {
       result = modulePath;
     } else {
-      npmName = getScopedModuleName(name);
+      npmName = getScopedModuleName(name, pkg);
       modulePath = npmName && path.resolve(process.cwd(), 'node_modules', npmName);
       result = modulePath;
     }
@@ -49,4 +50,3 @@ module.exports = getComponentPath;
 
 // For testing
 module.exports.setGetComponentName = (mod) => { getComponentName = mod; };
-module.exports.setPackageConfiguration = (val) => { pkg = val; };

--- a/lib/getComponentPath/index.test.js
+++ b/lib/getComponentPath/index.test.js
@@ -19,8 +19,6 @@ describe(_.startCase(filename), function () {
     sandbox.stub(fs, 'existsSync');
     sandbox.stub(path, 'resolve');
 
-    // package file can never be real
-    lib.setPackageConfiguration(pkg);
     lib.setGetComponentName(getComponentName);
     lib.cache = new _.memoize.Cache();
   });
@@ -46,19 +44,19 @@ describe(_.startCase(filename), function () {
     });
 
     it('returns null if name isn\'t a component', function () {
-      expect(lib('c0')).to.equal(null);
+      expect(lib('c0', pkg)).to.equal(null);
     });
 
     it('gets an internal path', function () {
-      expect(lib('c1')).to.equal('components/c1');
+      expect(lib('c1', pkg)).to.equal('components/c1');
     });
 
     it('gets an npm path', function () {
-      expect(lib('clay-c3')).to.equal('node_modules/clay-c3');
+      expect(lib('clay-c3', pkg)).to.equal('node_modules/clay-c3');
     });
 
     it('gets a scoped npm path', function () {
-      expect(lib('clay-c5')).to.equal('node_modules/@a/clay-c5');
+      expect(lib('clay-c5', pkg)).to.equal('node_modules/@a/clay-c5');
     });
   });
 });

--- a/lib/getComponents/index.js
+++ b/lib/getComponents/index.js
@@ -7,16 +7,16 @@ const _ = require('lodash'),
     'clay-sitemaps'
   ];
 
-var getFolders = require('../getFolders'),
-  pkg = require(path.resolve(process.cwd(), 'package.json'));
+var getFolders = require('../getFolders');
 
 /**
  * Get array of component names, from node_modules and components folder.
  *
  * Should only occur once!
+ * @param {object} pkg injected for testing
  * @return {[]}
  */
-function getComponents() {
+function getComponents(pkg = require(path.resolve(process.cwd(), 'package.json'))) {
   const npmComponents = _(pkg.dependencies).map(function (version, name) {
     if (_.includes(name, 'clay-') && !_.includes(IGNORED_CLAY_MODULES, name) ) {
       // this is a clay component
@@ -36,7 +36,6 @@ function getComponents() {
 module.exports = _.memoize(getComponents);
 
 // For testing
-module.exports.setPackageConfiguration = (val) => { pkg = val; };
 module.exports.setDeps = (gF) => {
   getFolders = gF;
 };

--- a/lib/getComponents/index.test.js
+++ b/lib/getComponents/index.test.js
@@ -16,9 +16,6 @@ describe(_.startCase(filename), function () {
     getFolders = sandbox.stub();
     lib.setDeps(getFolders);
     lib.cache = new _.memoize.Cache();
-
-    // package file can never be real
-    lib.setPackageConfiguration(pkg);
   });
 
   afterEach(function () {
@@ -28,20 +25,19 @@ describe(_.startCase(filename), function () {
   describe('getComponents', function () {
     it('returns empty array if no components', function () {
       getFolders.returns([]);
-      lib.setPackageConfiguration({ dependencies: [] });
-      expect(lib()).to.eql([]);
+      expect(lib({ dependencies: [] })).to.eql([]);
     });
 
     it('gets a list of internal components', function () {
       getFolders.returns(['c1', 'c2', 'c3']);
 
-      expect(lib()).to.contain('c1', 'c2');
+      expect(lib(pkg)).to.contain('c1', 'c2');
     });
 
     it('gets a list of npm components', function () {
       getFolders.returns([]);
 
-      expect(lib()).to.contain('clay-c3', 'clay-c4');
+      expect(lib(pkg)).to.contain('clay-c3', 'clay-c4');
     });
   });
 });


### PR DESCRIPTION
This changes how `amphora-fs` looks for `package.json` files. Currently, it tries to `require()` them right when you import the library, which means anything using it _must_ run inside another npm library. For consumers like `claycli`, we'd like to run them anywhere while still using `amphora-fs` for clay file handling stuff, so this moves the `package.json` handling to when you call the actual methods that need to look at the `package.json` file.

This fixes https://github.com/clay/claycli/issues/95